### PR TITLE
feat(proto,types): CreateSessionRequest の cookies を map<string,string> から repeated Cookie (配列) に変更し関連コードを更新

### DIFF
--- a/e2e.runbook.yml
+++ b/e2e.runbook.yml
@@ -11,7 +11,14 @@ steps:
       browser_proxy.v1.BrowserProxyService/CreateSession:
         message:
           cookies:
-            test_cookie: "test_value"
+            - name: "test_cookie"
+              value: "test_value"
+              domain: ".example.com"
+              path: "/"
+              expires: -1
+              http_only: false
+              secure: false
+              same_site: "Lax"
           default_headers:
             User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
     test: |

--- a/proto/browser_proxy/v1/browser_proxy.proto
+++ b/proto/browser_proxy/v1/browser_proxy.proto
@@ -27,7 +27,7 @@ service BrowserProxyService {
 
 // Request to create a new session
 message CreateSessionRequest {
-  map<string, string> cookies = 1; // Authentication cookies (e.g., FANBOXSESSID)
+  repeated Cookie cookies = 1; // Authentication cookies with full metadata
   map<string, string> default_headers = 2; // Common headers (e.g., User-Agent)
 }
 

--- a/src/application/usecases/CreateSessionUseCase.test.ts
+++ b/src/application/usecases/CreateSessionUseCase.test.ts
@@ -17,7 +17,18 @@ describe("CreateSessionUseCase", () => {
 		} as unknown as PlaywrightAdapter;
 
 		const useCase = new CreateSessionUseCase(mockRepository, mockAdapter);
-		const cookies = { sessionCookie: "abc123" };
+		const cookies = [
+			{
+				name: "sessionCookie",
+				value: "abc123",
+				domain: ".example.com",
+				path: "/",
+				expires: -1,
+				httpOnly: false,
+				secure: true,
+				sameSite: "Lax" as const,
+			},
+		];
 		const headers = { "User-Agent": "test-agent" };
 
 		const sessionId = await useCase.execute(cookies, headers);
@@ -47,8 +58,8 @@ describe("CreateSessionUseCase", () => {
 
 		const useCase = new CreateSessionUseCase(mockRepository, mockAdapter);
 
-		const sessionId = await useCase.execute({}, {});
+		const sessionId = await useCase.execute([], {});
 
-		expect(mockAdapter.createContext).toHaveBeenCalledWith(sessionId, {}, {});
+		expect(mockAdapter.createContext).toHaveBeenCalledWith(sessionId, [], {});
 	});
 });

--- a/src/domain/entities/Session.test.ts
+++ b/src/domain/entities/Session.test.ts
@@ -6,12 +6,34 @@ describe("Session", () => {
 		it("should create a session with required properties", () => {
 			const session = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 			);
 
 			expect(session.id).toBe("session-123");
-			expect(session.cookies).toEqual({ cookie1: "value1" });
+			expect(session.cookies).toEqual([
+				{
+					name: "cookie1",
+					value: "value1",
+					domain: ".example.com",
+					path: "/",
+					expires: -1,
+					httpOnly: false,
+					secure: true,
+					sameSite: "Lax",
+				},
+			]);
 			expect(session.defaultHeaders).toEqual({ "User-Agent": "test" });
 			expect(session.pageId).toBeUndefined();
 		});
@@ -19,7 +41,18 @@ describe("Session", () => {
 		it("should create a session with pageId", () => {
 			const session = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 				"page-456",
 			);
@@ -33,7 +66,18 @@ describe("Session", () => {
 		it("should return a new session with updated pageId", () => {
 			const originalSession = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 			);
 
@@ -41,7 +85,18 @@ describe("Session", () => {
 
 			expect(updatedSession).not.toBe(originalSession);
 			expect(updatedSession.id).toBe("session-123");
-			expect(updatedSession.cookies).toEqual({ cookie1: "value1" });
+			expect(updatedSession.cookies).toEqual([
+				{
+					name: "cookie1",
+					value: "value1",
+					domain: ".example.com",
+					path: "/",
+					expires: -1,
+					httpOnly: false,
+					secure: true,
+					sameSite: "Lax",
+				},
+			]);
 			expect(updatedSession.defaultHeaders).toEqual({ "User-Agent": "test" });
 			expect(updatedSession.pageId).toBe("page-456");
 		});
@@ -49,7 +104,18 @@ describe("Session", () => {
 		it("should not mutate the original session", () => {
 			const originalSession = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 			);
 
@@ -63,7 +129,18 @@ describe("Session", () => {
 		it("should return false when pageId is undefined", () => {
 			const session = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 			);
 
@@ -73,7 +150,18 @@ describe("Session", () => {
 		it("should return true when pageId is set", () => {
 			const session = new Session(
 				"session-123",
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 				"page-456",
 			);

--- a/src/infrastructure/grpc/generated/browser_proxy.ts
+++ b/src/infrastructure/grpc/generated/browser_proxy.ts
@@ -4,12 +4,15 @@ import type { MessageTypeDefinition } from '@grpc/proto-loader';
 import type { BrowserProxyServiceClient as _browser_proxy_v1_BrowserProxyServiceClient, BrowserProxyServiceDefinition as _browser_proxy_v1_BrowserProxyServiceDefinition } from './browser_proxy/v1/BrowserProxyService';
 import type { CloseSessionRequest as _browser_proxy_v1_CloseSessionRequest, CloseSessionRequest__Output as _browser_proxy_v1_CloseSessionRequest__Output } from './browser_proxy/v1/CloseSessionRequest';
 import type { CloseSessionResponse as _browser_proxy_v1_CloseSessionResponse, CloseSessionResponse__Output as _browser_proxy_v1_CloseSessionResponse__Output } from './browser_proxy/v1/CloseSessionResponse';
+import type { Cookie as _browser_proxy_v1_Cookie, Cookie__Output as _browser_proxy_v1_Cookie__Output } from './browser_proxy/v1/Cookie';
 import type { CreateSessionRequest as _browser_proxy_v1_CreateSessionRequest, CreateSessionRequest__Output as _browser_proxy_v1_CreateSessionRequest__Output } from './browser_proxy/v1/CreateSessionRequest';
 import type { CreateSessionResponse as _browser_proxy_v1_CreateSessionResponse, CreateSessionResponse__Output as _browser_proxy_v1_CreateSessionResponse__Output } from './browser_proxy/v1/CreateSessionResponse';
 import type { DownloadFileRequest as _browser_proxy_v1_DownloadFileRequest, DownloadFileRequest__Output as _browser_proxy_v1_DownloadFileRequest__Output } from './browser_proxy/v1/DownloadFileRequest';
 import type { DownloadFileResponse as _browser_proxy_v1_DownloadFileResponse, DownloadFileResponse__Output as _browser_proxy_v1_DownloadFileResponse__Output } from './browser_proxy/v1/DownloadFileResponse';
 import type { FetchHttpRequest as _browser_proxy_v1_FetchHttpRequest, FetchHttpRequest__Output as _browser_proxy_v1_FetchHttpRequest__Output } from './browser_proxy/v1/FetchHttpRequest';
 import type { FetchHttpResponse as _browser_proxy_v1_FetchHttpResponse, FetchHttpResponse__Output as _browser_proxy_v1_FetchHttpResponse__Output } from './browser_proxy/v1/FetchHttpResponse';
+import type { GetCookiesRequest as _browser_proxy_v1_GetCookiesRequest, GetCookiesRequest__Output as _browser_proxy_v1_GetCookiesRequest__Output } from './browser_proxy/v1/GetCookiesRequest';
+import type { GetCookiesResponse as _browser_proxy_v1_GetCookiesResponse, GetCookiesResponse__Output as _browser_proxy_v1_GetCookiesResponse__Output } from './browser_proxy/v1/GetCookiesResponse';
 import type { NavigatePageRequest as _browser_proxy_v1_NavigatePageRequest, NavigatePageRequest__Output as _browser_proxy_v1_NavigatePageRequest__Output } from './browser_proxy/v1/NavigatePageRequest';
 import type { NavigatePageResponse as _browser_proxy_v1_NavigatePageResponse, NavigatePageResponse__Output as _browser_proxy_v1_NavigatePageResponse__Output } from './browser_proxy/v1/NavigatePageResponse';
 
@@ -23,12 +26,15 @@ export interface ProtoGrpcType {
       BrowserProxyService: SubtypeConstructor<typeof grpc.Client, _browser_proxy_v1_BrowserProxyServiceClient> & { service: _browser_proxy_v1_BrowserProxyServiceDefinition }
       CloseSessionRequest: MessageTypeDefinition<_browser_proxy_v1_CloseSessionRequest, _browser_proxy_v1_CloseSessionRequest__Output>
       CloseSessionResponse: MessageTypeDefinition<_browser_proxy_v1_CloseSessionResponse, _browser_proxy_v1_CloseSessionResponse__Output>
+      Cookie: MessageTypeDefinition<_browser_proxy_v1_Cookie, _browser_proxy_v1_Cookie__Output>
       CreateSessionRequest: MessageTypeDefinition<_browser_proxy_v1_CreateSessionRequest, _browser_proxy_v1_CreateSessionRequest__Output>
       CreateSessionResponse: MessageTypeDefinition<_browser_proxy_v1_CreateSessionResponse, _browser_proxy_v1_CreateSessionResponse__Output>
       DownloadFileRequest: MessageTypeDefinition<_browser_proxy_v1_DownloadFileRequest, _browser_proxy_v1_DownloadFileRequest__Output>
       DownloadFileResponse: MessageTypeDefinition<_browser_proxy_v1_DownloadFileResponse, _browser_proxy_v1_DownloadFileResponse__Output>
       FetchHttpRequest: MessageTypeDefinition<_browser_proxy_v1_FetchHttpRequest, _browser_proxy_v1_FetchHttpRequest__Output>
       FetchHttpResponse: MessageTypeDefinition<_browser_proxy_v1_FetchHttpResponse, _browser_proxy_v1_FetchHttpResponse__Output>
+      GetCookiesRequest: MessageTypeDefinition<_browser_proxy_v1_GetCookiesRequest, _browser_proxy_v1_GetCookiesRequest__Output>
+      GetCookiesResponse: MessageTypeDefinition<_browser_proxy_v1_GetCookiesResponse, _browser_proxy_v1_GetCookiesResponse__Output>
       NavigatePageRequest: MessageTypeDefinition<_browser_proxy_v1_NavigatePageRequest, _browser_proxy_v1_NavigatePageRequest__Output>
       NavigatePageResponse: MessageTypeDefinition<_browser_proxy_v1_NavigatePageResponse, _browser_proxy_v1_NavigatePageResponse__Output>
     }

--- a/src/infrastructure/grpc/generated/browser_proxy/v1/BrowserProxyService.ts
+++ b/src/infrastructure/grpc/generated/browser_proxy/v1/BrowserProxyService.ts
@@ -10,6 +10,8 @@ import type { DownloadFileRequest as _browser_proxy_v1_DownloadFileRequest, Down
 import type { DownloadFileResponse as _browser_proxy_v1_DownloadFileResponse, DownloadFileResponse__Output as _browser_proxy_v1_DownloadFileResponse__Output } from '../../browser_proxy/v1/DownloadFileResponse';
 import type { FetchHttpRequest as _browser_proxy_v1_FetchHttpRequest, FetchHttpRequest__Output as _browser_proxy_v1_FetchHttpRequest__Output } from '../../browser_proxy/v1/FetchHttpRequest';
 import type { FetchHttpResponse as _browser_proxy_v1_FetchHttpResponse, FetchHttpResponse__Output as _browser_proxy_v1_FetchHttpResponse__Output } from '../../browser_proxy/v1/FetchHttpResponse';
+import type { GetCookiesRequest as _browser_proxy_v1_GetCookiesRequest, GetCookiesRequest__Output as _browser_proxy_v1_GetCookiesRequest__Output } from '../../browser_proxy/v1/GetCookiesRequest';
+import type { GetCookiesResponse as _browser_proxy_v1_GetCookiesResponse, GetCookiesResponse__Output as _browser_proxy_v1_GetCookiesResponse__Output } from '../../browser_proxy/v1/GetCookiesResponse';
 import type { NavigatePageRequest as _browser_proxy_v1_NavigatePageRequest, NavigatePageRequest__Output as _browser_proxy_v1_NavigatePageRequest__Output } from '../../browser_proxy/v1/NavigatePageRequest';
 import type { NavigatePageResponse as _browser_proxy_v1_NavigatePageResponse, NavigatePageResponse__Output as _browser_proxy_v1_NavigatePageResponse__Output } from '../../browser_proxy/v1/NavigatePageResponse';
 
@@ -46,6 +48,15 @@ export interface BrowserProxyServiceClient extends grpc.Client {
   fetchHttp(argument: _browser_proxy_v1_FetchHttpRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_FetchHttpResponse__Output>): grpc.ClientUnaryCall;
   fetchHttp(argument: _browser_proxy_v1_FetchHttpRequest, callback: grpc.requestCallback<_browser_proxy_v1_FetchHttpResponse__Output>): grpc.ClientUnaryCall;
   
+  GetCookies(argument: _browser_proxy_v1_GetCookiesRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  GetCookies(argument: _browser_proxy_v1_GetCookiesRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  GetCookies(argument: _browser_proxy_v1_GetCookiesRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  GetCookies(argument: _browser_proxy_v1_GetCookiesRequest, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  getCookies(argument: _browser_proxy_v1_GetCookiesRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  getCookies(argument: _browser_proxy_v1_GetCookiesRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  getCookies(argument: _browser_proxy_v1_GetCookiesRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  getCookies(argument: _browser_proxy_v1_GetCookiesRequest, callback: grpc.requestCallback<_browser_proxy_v1_GetCookiesResponse__Output>): grpc.ClientUnaryCall;
+  
   NavigatePage(argument: _browser_proxy_v1_NavigatePageRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_NavigatePageResponse__Output>): grpc.ClientUnaryCall;
   NavigatePage(argument: _browser_proxy_v1_NavigatePageRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_browser_proxy_v1_NavigatePageResponse__Output>): grpc.ClientUnaryCall;
   NavigatePage(argument: _browser_proxy_v1_NavigatePageRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_browser_proxy_v1_NavigatePageResponse__Output>): grpc.ClientUnaryCall;
@@ -66,6 +77,8 @@ export interface BrowserProxyServiceHandlers extends grpc.UntypedServiceImplemen
   
   FetchHttp: grpc.handleUnaryCall<_browser_proxy_v1_FetchHttpRequest__Output, _browser_proxy_v1_FetchHttpResponse>;
   
+  GetCookies: grpc.handleUnaryCall<_browser_proxy_v1_GetCookiesRequest__Output, _browser_proxy_v1_GetCookiesResponse>;
+  
   NavigatePage: grpc.handleUnaryCall<_browser_proxy_v1_NavigatePageRequest__Output, _browser_proxy_v1_NavigatePageResponse>;
   
 }
@@ -75,5 +88,6 @@ export interface BrowserProxyServiceDefinition extends grpc.ServiceDefinition {
   CreateSession: MethodDefinition<_browser_proxy_v1_CreateSessionRequest, _browser_proxy_v1_CreateSessionResponse, _browser_proxy_v1_CreateSessionRequest__Output, _browser_proxy_v1_CreateSessionResponse__Output>
   DownloadFile: MethodDefinition<_browser_proxy_v1_DownloadFileRequest, _browser_proxy_v1_DownloadFileResponse, _browser_proxy_v1_DownloadFileRequest__Output, _browser_proxy_v1_DownloadFileResponse__Output>
   FetchHttp: MethodDefinition<_browser_proxy_v1_FetchHttpRequest, _browser_proxy_v1_FetchHttpResponse, _browser_proxy_v1_FetchHttpRequest__Output, _browser_proxy_v1_FetchHttpResponse__Output>
+  GetCookies: MethodDefinition<_browser_proxy_v1_GetCookiesRequest, _browser_proxy_v1_GetCookiesResponse, _browser_proxy_v1_GetCookiesRequest__Output, _browser_proxy_v1_GetCookiesResponse__Output>
   NavigatePage: MethodDefinition<_browser_proxy_v1_NavigatePageRequest, _browser_proxy_v1_NavigatePageResponse, _browser_proxy_v1_NavigatePageRequest__Output, _browser_proxy_v1_NavigatePageResponse__Output>
 }

--- a/src/infrastructure/grpc/generated/browser_proxy/v1/CreateSessionRequest.ts
+++ b/src/infrastructure/grpc/generated/browser_proxy/v1/CreateSessionRequest.ts
@@ -1,12 +1,13 @@
 // Original file: proto/browser_proxy/v1/browser_proxy.proto
 
+import type { Cookie as _browser_proxy_v1_Cookie, Cookie__Output as _browser_proxy_v1_Cookie__Output } from '../../browser_proxy/v1/Cookie';
 
 export interface CreateSessionRequest {
-  'cookies'?: ({[key: string]: string});
+  'cookies'?: (_browser_proxy_v1_Cookie)[];
   'defaultHeaders'?: ({[key: string]: string});
 }
 
 export interface CreateSessionRequest__Output {
-  'cookies': ({[key: string]: string});
+  'cookies': (_browser_proxy_v1_Cookie__Output)[];
   'defaultHeaders': ({[key: string]: string});
 }

--- a/src/infrastructure/playwright/PlaywrightAdapter.ts
+++ b/src/infrastructure/playwright/PlaywrightAdapter.ts
@@ -45,11 +45,15 @@ export class PlaywrightAdapter {
 		});
 
 		// Set cookies
-		const cookieArray = Object.entries(cookies).map(([name, value]) => ({
-			name,
-			value,
-			domain: ".pixiv.net", // Default domain - should be configurable in production
-			path: "/",
+		const cookieArray = cookies.map((cookie) => ({
+			name: cookie.name,
+			value: cookie.value,
+			domain: cookie.domain,
+			path: cookie.path,
+			expires: cookie.expires === -1 ? -1 : cookie.expires,
+			httpOnly: cookie.httpOnly,
+			secure: cookie.secure,
+			sameSite: cookie.sameSite as "Strict" | "Lax" | "None",
 		}));
 
 		if (cookieArray.length > 0) {

--- a/src/presentation/grpc/controllers/BrowserProxyController.test.ts
+++ b/src/presentation/grpc/controllers/BrowserProxyController.test.ts
@@ -36,7 +36,18 @@ describe("BrowserProxyController", () => {
 
 			const mockCall = {
 				request: {
-					cookies: { cookie1: "value1" },
+					cookies: [
+						{
+							name: "cookie1",
+							value: "value1",
+							domain: ".example.com",
+							path: "/",
+							expires: -1,
+							httpOnly: false,
+							secure: true,
+							sameSite: "Lax",
+						},
+					],
 					defaultHeaders: { "User-Agent": "test" },
 				},
 			} as unknown as grpc.ServerUnaryCall<
@@ -53,7 +64,18 @@ describe("BrowserProxyController", () => {
 				sessionId: "session-123",
 			});
 			expect(mockCreateSessionUseCase.execute).toHaveBeenCalledWith(
-				{ cookie1: "value1" },
+				[
+					{
+						name: "cookie1",
+						value: "value1",
+						domain: ".example.com",
+						path: "/",
+						expires: -1,
+						httpOnly: false,
+						secure: true,
+						sameSite: "Lax",
+					},
+				],
 				{ "User-Agent": "test" },
 			);
 		});

--- a/src/presentation/grpc/controllers/BrowserProxyController.ts
+++ b/src/presentation/grpc/controllers/BrowserProxyController.ts
@@ -46,7 +46,7 @@ export class BrowserProxyController {
 			const { cookies, defaultHeaders } = call.request;
 
 			const sessionId = await this.createSessionUseCase.execute(
-				cookies ?? {},
+				cookies ?? [],
 				defaultHeaders ?? {},
 			);
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -8,9 +8,9 @@
 export type Headers = Record<string, string>;
 
 /**
- * Cookies represented as a key-value map
+ * Cookies represented as an array of Cookie objects
  */
-export type Cookies = Record<string, string>;
+export type Cookies = Cookie[];
 
 /**
  * HTTP response structure


### PR DESCRIPTION
- proto: CreateSessionRequest.cookies を map から repeated Cookie に変更
- generated gRPC 型定義に Cookie/GetCookies を追加・更新
- 共通型 Cookies を Record から Cookie[] に変更
- PlaywrightAdapter, Controller, UseCase, Entity のテストを配列形式の Cookie に対応するよう修正
- e2e.runbook.yml のクッキー定義をオブジェクト配列に変更
