### PR TITLE
feat(proto,types,playwright,application,presentation,grpc,test): Fetc…

### DIFF
--- a/proto/browser_proxy/v1/browser_proxy.proto
+++ b/proto/browser_proxy/v1/browser_proxy.proto
@@ -56,6 +56,7 @@ message FetchHttpRequest {
   string session_id = 1;
   string url = 2;
   map<string, string> headers = 3; // Additional headers for this request
+  string credential = 4; // Credential mode for fetch request (e.g., "include", "omit", "same-origin")
 }
 
 // Response containing HTTP fetch result

--- a/src/application/usecases/FetchHttpUseCase.test.ts
+++ b/src/application/usecases/FetchHttpUseCase.test.ts
@@ -45,6 +45,7 @@ describe("FetchHttpUseCase", () => {
 			"session-123",
 			"https://api.example.com/data",
 			{ Accept: "application/json" },
+			undefined,
 		);
 	});
 

--- a/src/application/usecases/FetchHttpUseCase.ts
+++ b/src/application/usecases/FetchHttpUseCase.ts
@@ -16,6 +16,7 @@ export class FetchHttpUseCase {
 		sessionId: string,
 		url: string,
 		headers: Headers,
+		credential?: string,
 	): Promise<HttpResponse> {
 		// Verify session exists
 		const session = await this.sessionRepository.findById(sessionId);
@@ -31,6 +32,11 @@ export class FetchHttpUseCase {
 		}
 
 		// Fetch HTTP content
-		return await this.playwrightAdapter.fetchHttp(sessionId, url, headers);
+		return await this.playwrightAdapter.fetchHttp(
+			sessionId,
+			url,
+			headers,
+			credential,
+		);
 	}
 }

--- a/src/infrastructure/grpc/generated/browser_proxy/v1/FetchHttpRequest.ts
+++ b/src/infrastructure/grpc/generated/browser_proxy/v1/FetchHttpRequest.ts
@@ -5,10 +5,12 @@ export interface FetchHttpRequest {
   'sessionId'?: (string);
   'url'?: (string);
   'headers'?: ({[key: string]: string});
+  'credential'?: (string);
 }
 
 export interface FetchHttpRequest__Output {
   'sessionId': (string);
   'url': (string);
   'headers': ({[key: string]: string});
+  'credential': (string);
 }

--- a/src/infrastructure/playwright/PlaywrightAdapter.ts
+++ b/src/infrastructure/playwright/PlaywrightAdapter.ts
@@ -108,6 +108,7 @@ export class PlaywrightAdapter {
 		sessionId: string,
 		url: string,
 		headers: Headers,
+		credential?: string,
 	): Promise<HttpResponse> {
 		const contextData = this.contexts.get(sessionId);
 		if (!contextData?.page) {
@@ -117,8 +118,12 @@ export class PlaywrightAdapter {
 		try {
 			// Execute fetch within the browser context
 			const result = await contextData.page.evaluate(
-				async ({ url, headers }) => {
-					const response = await fetch(url, { headers });
+				async ({ url, headers, credential }) => {
+					const fetchOptions: RequestInit = { headers };
+					if (credential) {
+						fetchOptions.credentials = credential as RequestCredentials;
+					}
+					const response = await fetch(url, fetchOptions);
 					const body = await response.arrayBuffer();
 					const responseHeaders: Record<string, string> = {};
 
@@ -132,7 +137,7 @@ export class PlaywrightAdapter {
 						body: Array.from(new Uint8Array(body)),
 					};
 				},
-				{ url, headers },
+				{ url, headers, credential },
 			);
 
 			return {

--- a/src/presentation/grpc/controllers/BrowserProxyController.test.ts
+++ b/src/presentation/grpc/controllers/BrowserProxyController.test.ts
@@ -183,6 +183,7 @@ describe("BrowserProxyController", () => {
 					sessionId: "session-123",
 					url: "https://api.example.com/data",
 					headers: { Accept: "application/json" },
+					credential: "include",
 				},
 			} as unknown as grpc.ServerUnaryCall<
 				FetchHttpRequest__Output,
@@ -194,6 +195,12 @@ describe("BrowserProxyController", () => {
 
 			await controller.FetchHttp(mockCall, mockCallback);
 
+			expect(mockFetchHttpUseCase.execute).toHaveBeenCalledWith(
+				"session-123",
+				"https://api.example.com/data",
+				{ Accept: "application/json" },
+				"include",
+			);
 			expect(mockCallback).toHaveBeenCalledWith(null, {
 				statusCode: 200,
 				headers: { "content-type": "application/json" },

--- a/src/presentation/grpc/controllers/BrowserProxyController.ts
+++ b/src/presentation/grpc/controllers/BrowserProxyController.ts
@@ -91,7 +91,7 @@ export class BrowserProxyController {
 	FetchHttp: grpc.handleUnaryCall<FetchHttpRequest__Output, FetchHttpResponse> =
 		async (call, callback) => {
 			try {
-				const { sessionId, url, headers } = call.request;
+				const { sessionId, url, headers, credential } = call.request;
 
 				if (!sessionId || !url) {
 					throw new Error("sessionId and url are required");
@@ -101,6 +101,7 @@ export class BrowserProxyController {
 					sessionId,
 					url,
 					headers ?? {},
+					credential,
 				);
 
 				callback(null, {


### PR DESCRIPTION
…hHttp に credential オプションを追加

- proto 定義に credential フィールドを追加し生成型を更新
- PlaywrightAdapter.fetchHttp が credential を受け取り page.evaluate 内の fetch に credentials を設定するよう変更
- FetchHttpUseCase と BrowserProxyController で credential を受け渡すよう修正
- 関連テストを更新して credential を扱うケースを追加